### PR TITLE
revert: "chore(deps): update dependency parse-type to v0.6.4 (#44)"

### DIFF
--- a/end-to-end-tests/requirements.txt
+++ b/end-to-end-tests/requirements.txt
@@ -1,4 +1,4 @@
 behave==1.2.6
 parse==1.19.0
-parse-type==0.6.4
+parse-type==0.6.0
 six==1.16.0


### PR DESCRIPTION
This reverts commit 0314fcf9651db5acde8f016eba7030163d7a1fc4.

As it seems to be causing Python formatting checks to fail.