### PR TITLE
build: autopep8 upgrade

### DIFF
--- a/end-to-end-tests/autopep8.requirements.txt
+++ b/end-to-end-tests/autopep8.requirements.txt
@@ -1,2 +1,2 @@
-autopep8==2.0.4
-pycodestyle==2.11.0
+autopep8==2.3.1
+pycodestyle==2.12.1


### PR DESCRIPTION
The Python formatting check is failing with the error, unsure why it is
has suddenly failing with a pinned runtime/dependencies.

```
  +check-python-formatting *failed* |   File "/usr/local/lib/python3.13/site-packages/autopep8.py", line 172, in open_with_encoding
  +check-python-formatting *failed* |     encoding = detect_encoding(filename, limit_byte_check=limit_byte_check)
  +check-python-formatting *failed* |   File "/usr/local/lib/python3.13/site-packages/autopep8.py", line 182, in detect_encoding
  +check-python-formatting *failed* |     from lib2to3.pgen2 import tokenize as lib2to3_tokenize
  +check-python-formatting *failed* | ModuleNotFoundError: No module named 'lib2to3'
```

lib2to3 has been deprecated since Python 3.10.

* https://github.com/pyodide/pyodide/issues/1640

Autopep8 version 2.1.0 has removed the dependency on lib2to3.

* https://github.com/hhatto/autopep8/issues/581